### PR TITLE
Made Config is now part of the client. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.6
+- Made Config object part of the Client, instead of being a singleton.
+  This allows multiple clients to have different configurations
+
 ## 2.2.5
 - Fixed a typo in RefundResponse
 - Fixed a wrong enum value in ResponseType

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.feelio</groupId>
     <artifactId>mollie</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/feelio/mollie/Client.java
+++ b/src/main/java/be/feelio/mollie/Client.java
@@ -10,14 +10,17 @@ public class Client {
     @Getter
     private final String endpoint;
 
+    @Getter
+    private final Config config = new Config();
+
 
     public Client(String apiKey) {
         this.endpoint = "https://api.mollie.com/v2";
 
         // TODO: Check valid api key
-        Config.getInstance().setApiKey(apiKey);
-        Config.getInstance().setAccessToken(null);
-        Config.getInstance().setTestMode(false);
+        config.setApiKey(apiKey);
+        config.setAccessToken(null);
+        config.setTestMode(false);
 
         initUniRest();
     }
@@ -29,28 +32,28 @@ public class Client {
      */
     public void setAccessToken(String accessToken) {
         // TODO: Check valid access token
-        Config.getInstance().setAccessToken(accessToken);
+        config.setAccessToken(accessToken);
     }
 
     /**
      * Removes the access token, the requests will start using the api key again
      */
     public void revokeAccessToken() {
-        Config.getInstance().setAccessToken(null);
+        config.setAccessToken(null);
     }
 
     /**
      * Enable test mode if you are using an access token
      */
     public void enableTestMode() {
-        Config.getInstance().setTestMode(true);
+        config.setTestMode(true);
     }
 
     /**
      * Disable test mode if you are using an access token
      */
     public void disableTestMode() {
-        Config.getInstance().setTestMode(false);
+        config.setTestMode(false);
     }
 
     /**
@@ -59,7 +62,7 @@ public class Client {
      * @return ConnectHandler object
      */
     public ConnectHandler connect() {
-        return new ConnectHandler();
+        return new ConnectHandler(config);
     }
 
     /**
@@ -68,7 +71,7 @@ public class Client {
      * @return PaymentHandler object
      */
     public PaymentHandler payments() {
-        return new PaymentHandler(endpoint);
+        return new PaymentHandler(endpoint, config);
     }
 
     /**
@@ -77,7 +80,7 @@ public class Client {
      * @return MethodHandler object
      */
     public MethodHandler methods() {
-        return new MethodHandler(endpoint);
+        return new MethodHandler(endpoint, config);
     }
 
     /**
@@ -86,7 +89,7 @@ public class Client {
      * @return RefundHandler object
      */
     public RefundHandler refunds() {
-        return new RefundHandler(endpoint);
+        return new RefundHandler(endpoint, config);
     }
 
     /**
@@ -95,7 +98,7 @@ public class Client {
      * @return ChargebackHandler object
      */
     public ChargebackHandler chargebacks() {
-        return new ChargebackHandler(endpoint);
+        return new ChargebackHandler(endpoint, config);
     }
 
     /**
@@ -104,7 +107,7 @@ public class Client {
      * @return CaptureHandler object
      */
     public CaptureHandler captures() {
-        return new CaptureHandler(endpoint);
+        return new CaptureHandler(endpoint, config);
     }
 
     /**
@@ -113,7 +116,7 @@ public class Client {
      * @return OrderHandler object
      */
     public OrderHandler orders() {
-        return new OrderHandler(endpoint);
+        return new OrderHandler(endpoint, config);
     }
 
     /**
@@ -122,7 +125,7 @@ public class Client {
      * @return ShipmentHandler object
      */
     public ShipmentHandler shipments() {
-        return new ShipmentHandler(endpoint);
+        return new ShipmentHandler(endpoint, config);
     }
 
     /**
@@ -131,7 +134,7 @@ public class Client {
      * @return CustomerHandler object
      */
     public CustomerHandler customers() {
-        return new CustomerHandler(endpoint);
+        return new CustomerHandler(endpoint, config);
     }
 
     /**
@@ -140,7 +143,7 @@ public class Client {
      * @return MandateHandler object
      */
     public MandateHandler mandates() {
-        return new MandateHandler(endpoint);
+        return new MandateHandler(endpoint, config);
     }
 
     /**
@@ -149,7 +152,7 @@ public class Client {
      * @return MethodHandler object
      */
     public SubscriptionHandler subscriptions() {
-        return new SubscriptionHandler(endpoint);
+        return new SubscriptionHandler(endpoint, config);
     }
 
     /**
@@ -158,7 +161,7 @@ public class Client {
      * @return PermissionHandler object
      */
     public PermissionHandler permissions() {
-        return new PermissionHandler(endpoint);
+        return new PermissionHandler(endpoint, config);
     }
 
     /**
@@ -167,7 +170,7 @@ public class Client {
      * @return OrganizationHandler object
      */
     public OrganizationHandler organizations() {
-        return new OrganizationHandler(endpoint);
+        return new OrganizationHandler(endpoint, config);
     }
 
     /**
@@ -176,7 +179,7 @@ public class Client {
      * @return ProfileHandler object
      */
     public ProfileHandler profiles() {
-        return new ProfileHandler(endpoint);
+        return new ProfileHandler(endpoint, config);
     }
 
     /**
@@ -185,7 +188,7 @@ public class Client {
      * @return OnboardingHandler object
      */
     public OnboardingHandler onboarding() {
-        return new OnboardingHandler(endpoint);
+        return new OnboardingHandler(endpoint, config);
     }
 
     /**
@@ -194,7 +197,7 @@ public class Client {
      * @return SettlementHandler object
      */
     public SettlementHandler settlements() {
-        return new SettlementHandler(endpoint);
+        return new SettlementHandler(endpoint, config);
     }
 
     /**
@@ -203,7 +206,7 @@ public class Client {
      * @return InvoiceHandler object
      */
     public InvoiceHandler invoices() {
-        return new InvoiceHandler(endpoint);
+        return new InvoiceHandler(endpoint, config);
     }
 
     /**
@@ -212,11 +215,11 @@ public class Client {
      * @return MiscellaneousHandler object
      */
     public MiscellaneousHandler miscellaneous() {
-        return new MiscellaneousHandler(endpoint);
+        return new MiscellaneousHandler(endpoint, config);
     }
 
     private void initUniRest() {
         Unirest.config()
-            .setObjectMapper(new OAuthAwareObjectMapper());
+            .setObjectMapper(new OAuthAwareObjectMapper(config));
     }
 }

--- a/src/main/java/be/feelio/mollie/Client.java
+++ b/src/main/java/be/feelio/mollie/Client.java
@@ -11,13 +11,14 @@ public class Client {
     private final String endpoint;
 
     @Getter
-    private final Config config = new Config();
+    private final Config config;
 
 
     public Client(String apiKey) {
         this.endpoint = "https://api.mollie.com/v2";
 
         // TODO: Check valid api key
+        config = new Config();
         config.setApiKey(apiKey);
         config.setAccessToken(null);
         config.setTestMode(false);

--- a/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
+++ b/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
@@ -11,6 +11,12 @@ import java.io.IOException;
 
 public class OAuthAwareObjectMapper implements ObjectMapper {
 
+    private final Config config;
+
+    public OAuthAwareObjectMapper(Config config){
+        this.config = config;
+    }
+
     @Override
     public <T> T readValue(String value, Class<T> type) {
         try {
@@ -24,7 +30,7 @@ public class OAuthAwareObjectMapper implements ObjectMapper {
     public String writeValue(Object value) {
         try {
             JsonNode node = ObjectMapperService.getInstance().getMapper().valueToTree(value);
-            if (node.isObject() && Config.getInstance().shouldAddTestMode()) {
+            if (node.isObject() && config.shouldAddTestMode()) {
                 ObjectNode object = (ObjectNode) node;
                 object.put("testmode", true);
                 return ObjectMapperService.getInstance().getMapper().writeValueAsString(object);

--- a/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
+++ b/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
@@ -13,7 +13,7 @@ public class OAuthAwareObjectMapper implements ObjectMapper {
 
     private final Config config;
 
-    public OAuthAwareObjectMapper(Config config){
+    public OAuthAwareObjectMapper(Config config) {
         this.config = config;
     }
 

--- a/src/main/java/be/feelio/mollie/handler/AbstractHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/AbstractHandler.java
@@ -19,11 +19,13 @@ public abstract class AbstractHandler {
     private final Logger log;
     private final String baseUrl;
     private final ObjectMapper mapper;
+    protected final Config config;
 
-    AbstractHandler(String baseUrl, Logger log) {
+    AbstractHandler(String baseUrl, Logger log, Config config) {
         this.baseUrl = baseUrl;
         this.log = log;
         this.mapper = ObjectMapperService.getInstance().getMapper();
+        this.config = config;
     }
 
     protected HttpResponse<String> get(String uri) throws IOException, MollieException {
@@ -31,7 +33,7 @@ public abstract class AbstractHandler {
     }
 
     protected HttpResponse<String> get(String uri, QueryParams params) throws IOException, MollieException {
-        if (Config.getInstance().shouldAddTestMode() && !params.containsKey("testmode")) {
+        if (config.shouldAddTestMode() && !params.containsKey("testmode")) {
             params.put("testmode", "true");
         }
 
@@ -42,7 +44,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .get(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .asString();
 
         validateResponse(response);
@@ -60,7 +62,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .post(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .asString();
 
         validateResponse(response);
@@ -82,7 +84,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .post(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .body(body)
                 .asString();
 
@@ -105,7 +107,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .patch(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .body(body)
                 .asString();
 
@@ -121,7 +123,7 @@ public abstract class AbstractHandler {
 
     protected HttpResponse<String> delete(String uri, QueryParams params) throws IOException, MollieException {
         Map<String, Object> body = new HashMap<>();
-        if (Config.getInstance().shouldAddTestMode()) {
+        if (config.shouldAddTestMode()) {
             body.put("testmode", "true");
         }
 
@@ -132,7 +134,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .delete(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .body(body)
                 .asString();
 
@@ -151,7 +153,7 @@ public abstract class AbstractHandler {
         HttpResponse<String> response = Unirest
                 .delete(url)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + Config.getInstance().getBearerToken())
+                .header("Authorization", "Bearer " + config.getBearerToken())
                 .body(body)
                 .asString();
 

--- a/src/main/java/be/feelio/mollie/handler/CaptureHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/CaptureHandler.java
@@ -4,6 +4,7 @@ import be.feelio.mollie.data.capture.CaptureListResponse;
 import be.feelio.mollie.data.capture.CaptureResponse;
 import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,8 +24,8 @@ public class CaptureHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(CaptureHandler.class);
 
-    public CaptureHandler(String baseUrl) {
-        super(baseUrl, log);
+    public CaptureHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/ChargebackHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/ChargebackHandler.java
@@ -4,6 +4,7 @@ import be.feelio.mollie.exception.MollieException;
 import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.chargeback.ChargebackListResponse;
 import be.feelio.mollie.data.chargeback.ChargebackResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,8 +24,8 @@ public class ChargebackHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ChargebackHandler.class);
 
-    public ChargebackHandler(String baseUrl) {
-        super(baseUrl, log);
+    public ChargebackHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/ConnectHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/ConnectHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.connect.RevokeTokenRequest;
 import be.feelio.mollie.data.connect.TokenRequest;
 import be.feelio.mollie.data.connect.TokenResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import be.feelio.mollie.util.UrlUtils;
@@ -25,8 +26,8 @@ public class ConnectHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ConnectHandler.class);
 
-    public ConnectHandler() {
-        super(null, log);
+    public ConnectHandler(Config config) {
+        super(null, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/CustomerHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/CustomerHandler.java
@@ -8,6 +8,7 @@ import be.feelio.mollie.data.customer.CustomerListResponse;
 import be.feelio.mollie.data.customer.CustomerResponse;
 import be.feelio.mollie.data.payment.PaymentListResponse;
 import be.feelio.mollie.data.payment.PaymentResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,8 +28,8 @@ public class CustomerHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(CustomerHandler.class);
 
-    public CustomerHandler(String baseUrl) {
-        super(baseUrl, log);
+    public CustomerHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/InvoiceHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/InvoiceHandler.java
@@ -4,6 +4,7 @@ import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.invoice.InvoiceResponse;
 import be.feelio.mollie.data.invoice.InvoicesListResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,8 +24,8 @@ public class InvoiceHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(InvoiceHandler.class);
 
-    public InvoiceHandler(String baseApiUrl) {
-        super(baseApiUrl, log);
+    public InvoiceHandler(String baseApiUrl, Config config) {
+        super(baseApiUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/MandateHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/MandateHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.mandate.MandateRequest;
 import be.feelio.mollie.data.mandate.MandateListResponse;
 import be.feelio.mollie.data.mandate.MandateResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,8 +25,8 @@ public class MandateHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(MandateHandler.class);
 
-    public MandateHandler(String baseUrl) {
-        super(baseUrl, log);
+    public MandateHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/MethodHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/MethodHandler.java
@@ -4,6 +4,7 @@ import be.feelio.mollie.exception.MollieException;
 import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.method.MethodListResponse;
 import be.feelio.mollie.data.method.MethodResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,8 +24,8 @@ public class MethodHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(MethodHandler.class);
 
-    public MethodHandler(String baseUrl) {
-        super(baseUrl, log);
+    public MethodHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/MiscellaneousHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/MiscellaneousHandler.java
@@ -17,8 +17,8 @@ public class MiscellaneousHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(MiscellaneousHandler.class);
 
-    public MiscellaneousHandler(String baseApiUrl) {
-        super(baseApiUrl, log);
+    public MiscellaneousHandler(String baseApiUrl, Config config) {
+        super(baseApiUrl, log, config);
     }
 
     /**
@@ -42,7 +42,7 @@ public class MiscellaneousHandler extends AbstractHandler {
      * @throws MollieException when something went wrong
      */
     public ApplePaySessionResponse requestApplePaySession(String profileId) throws MollieException {
-        if (Config.getInstance().getAccessToken() == null) {
+        if (config.getAccessToken() == null) {
             throw new MollieException(
                     "To request an apple pay session with only a profile ID you must use an access token",
                     new HashMap<>()

--- a/src/main/java/be/feelio/mollie/handler/OnboardingHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/OnboardingHandler.java
@@ -3,6 +3,7 @@ package be.feelio.mollie.handler;
 import be.feelio.mollie.data.onboarding.OnboardingRequest;
 import be.feelio.mollie.data.onboarding.OnboardingResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import kong.unirest.HttpResponse;
@@ -21,8 +22,8 @@ public class OnboardingHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(OnboardingHandler.class);
 
-    public OnboardingHandler(String baseUrl) {
-        super(baseUrl, log);
+    public OnboardingHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/OrderHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/OrderHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.order.*;
 import be.feelio.mollie.data.payment.PaymentResponse;
 import be.feelio.mollie.data.refund.RefundResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,8 +25,8 @@ public class OrderHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(OrderHandler.class);
 
-    public OrderHandler(String baseUrl) {
-        super(baseUrl, log);
+    public OrderHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/OrganizationHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/OrganizationHandler.java
@@ -2,6 +2,7 @@ package be.feelio.mollie.handler;
 
 import be.feelio.mollie.data.organization.OrganizationResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import kong.unirest.HttpResponse;
@@ -20,8 +21,8 @@ public class OrganizationHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(OrganizationHandler.class);
 
-    public OrganizationHandler(String baseUrl) {
-        super(baseUrl, log);
+    public OrganizationHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/PaymentHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/PaymentHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.payment.PaymentRequest;
 import be.feelio.mollie.data.payment.PaymentListResponse;
 import be.feelio.mollie.data.payment.PaymentResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,8 +28,8 @@ public class PaymentHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(PaymentHandler.class);
 
-    public PaymentHandler(String baseUrl) {
-        super(baseUrl, log);
+    public PaymentHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
 
     }
 

--- a/src/main/java/be/feelio/mollie/handler/PermissionHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/PermissionHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.permission.Permission;
 import be.feelio.mollie.data.permission.PermissionListResponse;
 import be.feelio.mollie.data.permission.PermissionResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,8 +25,8 @@ public class PermissionHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(PermissionHandler.class);
 
-    public PermissionHandler(String baseUrl) {
-        super(baseUrl, log);
+    public PermissionHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/ProfileHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/ProfileHandler.java
@@ -7,6 +7,7 @@ import be.feelio.mollie.data.method.MethodResponse;
 import be.feelio.mollie.data.profile.ProfileListResponse;
 import be.feelio.mollie.data.profile.ProfileResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -26,8 +27,8 @@ public class ProfileHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ProfileHandler.class);
 
-    public ProfileHandler(String baseUrl) {
-        super(baseUrl, log);
+    public ProfileHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/RefundHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/RefundHandler.java
@@ -5,6 +5,7 @@ import be.feelio.mollie.data.common.Pagination;
 import be.feelio.mollie.data.refund.RefundRequest;
 import be.feelio.mollie.data.refund.RefundListResponse;
 import be.feelio.mollie.data.refund.RefundResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,8 +25,8 @@ public class RefundHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(RefundHandler.class);
 
-    public RefundHandler(String baseUrl) {
-        super(baseUrl, log);
+    public RefundHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/SettlementHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/SettlementHandler.java
@@ -8,6 +8,7 @@ import be.feelio.mollie.data.refund.RefundListResponse;
 import be.feelio.mollie.data.settlement.SettlementListResponse;
 import be.feelio.mollie.data.settlement.SettlementResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,8 +28,8 @@ public class SettlementHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(SettlementHandler.class);
 
-    public SettlementHandler(String baseUrl) {
-        super(baseUrl, log);
+    public SettlementHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/ShipmentHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/ShipmentHandler.java
@@ -6,6 +6,7 @@ import be.feelio.mollie.data.shipment.ShipmentUpdateRequest;
 import be.feelio.mollie.data.shipment.ShipmentListResponse;
 import be.feelio.mollie.data.shipment.ShipmentResponse;
 import be.feelio.mollie.exception.MollieException;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -25,8 +26,8 @@ public class ShipmentHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ShipmentHandler.class);
 
-    public ShipmentHandler(String baseUrl) {
-        super(baseUrl, log);
+    public ShipmentHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/handler/SubscriptionHandler.java
+++ b/src/main/java/be/feelio/mollie/handler/SubscriptionHandler.java
@@ -7,6 +7,7 @@ import be.feelio.mollie.data.subscription.UpdateSubscriptionRequest;
 import be.feelio.mollie.data.payment.PaymentListResponse;
 import be.feelio.mollie.data.subscription.SubscriptionListResponse;
 import be.feelio.mollie.data.subscription.SubscriptionResponse;
+import be.feelio.mollie.util.Config;
 import be.feelio.mollie.util.ObjectMapperService;
 import be.feelio.mollie.util.QueryParams;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -26,8 +27,8 @@ public class SubscriptionHandler extends AbstractHandler {
 
     private static final Logger log = LoggerFactory.getLogger(SubscriptionHandler.class);
 
-    public SubscriptionHandler(String baseUrl) {
-        super(baseUrl, log);
+    public SubscriptionHandler(String baseUrl, Config config) {
+        super(baseUrl, log, config);
     }
 
     /**

--- a/src/main/java/be/feelio/mollie/util/Config.java
+++ b/src/main/java/be/feelio/mollie/util/Config.java
@@ -7,12 +7,6 @@ import org.apache.commons.lang3.StringUtils;
 public final class Config {
 
     @Getter
-    private static Config instance = new Config();
-
-    private Config() {
-    }
-
-    @Getter
     @Setter
     private String apiKey;
 

--- a/src/test/java/be/feelio/mollie/ClientBuilderTest.java
+++ b/src/test/java/be/feelio/mollie/ClientBuilderTest.java
@@ -27,7 +27,7 @@ class ClientBuilderTest {
                 .build();
 
         assertNotNull(client);
-        assertEquals("org-token", Config.getInstance().getBearerToken());
+        assertEquals("org-token", client.getConfig().getBearerToken());
     }
 
     @Test
@@ -39,6 +39,6 @@ class ClientBuilderTest {
                 .build();
 
         assertNotNull(client);
-        assertTrue(Config.getInstance().isTestMode());
+        assertTrue(client.getConfig().isTestMode());
     }
 }

--- a/src/test/java/be/feelio/mollie/ClientTest.java
+++ b/src/test/java/be/feelio/mollie/ClientTest.java
@@ -12,7 +12,7 @@ class ClientTest {
         Client client = new Client("apiKey");
 
         assertEquals("https://api.mollie.com/v2", client.getEndpoint());
-        assertEquals("apiKey", Config.getInstance().getApiKey());
+        assertEquals("apiKey", client.getConfig().getApiKey());
     }
 
     @Test
@@ -21,7 +21,7 @@ class ClientTest {
 
         client.setAccessToken("access_token");
 
-        assertEquals("access_token", Config.getInstance().getAccessToken());
+        assertEquals("access_token", client.getConfig().getAccessToken());
     }
 
     @Test
@@ -30,11 +30,11 @@ class ClientTest {
 
         client.setAccessToken("access_token");
 
-        assertEquals("access_token", Config.getInstance().getAccessToken());
+        assertEquals("access_token", client.getConfig().getAccessToken());
 
         client.revokeAccessToken();
 
-        assertNull(Config.getInstance().getAccessToken());
+        assertNull(client.getConfig().getAccessToken());
     }
 
     @Test
@@ -42,7 +42,7 @@ class ClientTest {
         Client client = new Client("apiKey");
         client.enableTestMode();
 
-        assertTrue(Config.getInstance().isTestMode());
+        assertTrue(client.getConfig().isTestMode());
     }
 
     @Test
@@ -51,7 +51,17 @@ class ClientTest {
         client.enableTestMode();
         client.disableTestMode();
 
-        assertFalse(Config.getInstance().isTestMode());
+        assertFalse(client.getConfig().isTestMode());
+    }
+    
+    @Test
+    void twoClients(){
+        Client client1 = new Client("apiKey1");
+        Client client2 = new Client("apiKey2");
+
+        assertEquals("apiKey1",client1.getConfig().getApiKey());
+        assertEquals("apiKey2",client2.getConfig().getApiKey());
+        
     }
 
 }

--- a/src/test/java/be/feelio/mollie/OAuthAwareObjectMapperTest.java
+++ b/src/test/java/be/feelio/mollie/OAuthAwareObjectMapperTest.java
@@ -13,18 +13,21 @@ class OAuthAwareObjectMapperTest {
 
     private static final TestPojo POJO = new TestPojo("My Name");
 
-    private OAuthAwareObjectMapper objectMapper = new OAuthAwareObjectMapper();
+
 
     @Test
     void readValue() {
+        OAuthAwareObjectMapper objectMapper = new OAuthAwareObjectMapper(new Config());
         TestPojo pojo = objectMapper.readValue(JSON_TO_POJO, TestPojo.class);
         assertEquals("My Name", pojo.getName());
     }
 
     @Test
     void writeValue_withTestMode() {
-        Config.getInstance().setAccessToken("access_token");
-        Config.getInstance().setTestMode(true);
+        Config config = new Config();
+        config.setAccessToken("access_token");
+        config.setTestMode(true);
+        OAuthAwareObjectMapper objectMapper = new OAuthAwareObjectMapper(config);
 
         String result = objectMapper.writeValue(POJO);
 
@@ -34,8 +37,10 @@ class OAuthAwareObjectMapperTest {
 
     @Test
     void writeValue_noTestMode() {
-        Config.getInstance().setAccessToken("access_token");
-        Config.getInstance().setTestMode(false);
+        Config config = new Config();
+        config.setAccessToken("access_token");
+        config.setTestMode(false);
+        OAuthAwareObjectMapper objectMapper = new OAuthAwareObjectMapper(config);
 
         String result = objectMapper.writeValue(POJO);
 
@@ -45,7 +50,9 @@ class OAuthAwareObjectMapperTest {
 
     @Test
     void writeValue_noOAuth() {
-        Config.getInstance().setApiKey("api-key");
+        Config config = new Config();
+        config.setApiKey("api-key");
+        OAuthAwareObjectMapper objectMapper = new OAuthAwareObjectMapper(config);
 
         String result = objectMapper.writeValue(POJO);
 

--- a/src/test/java/be/feelio/mollie/util/ConfigTest.java
+++ b/src/test/java/be/feelio/mollie/util/ConfigTest.java
@@ -8,17 +8,19 @@ class ConfigTest {
 
     @Test
     void getBearerToken_apiKey() {
-        Config.getInstance().setApiKey("apiKey");
-        Config.getInstance().setAccessToken(null);
+        Config config = new Config();
+        config.setApiKey("apiKey");
+        config.setAccessToken(null);
 
-        assertEquals("apiKey", Config.getInstance().getBearerToken());
+        assertEquals("apiKey", config.getBearerToken());
     }
 
     @Test
     void getBearerToken_accessToken() {
-        Config.getInstance().setApiKey("apiKey");
-        Config.getInstance().setAccessToken("accessToken");
+        Config config = new Config();
+        config.setApiKey("apiKey");
+        config.setAccessToken("accessToken");
 
-        assertEquals("accessToken", Config.getInstance().getBearerToken());
+        assertEquals("accessToken", config.getBearerToken());
     }
 }


### PR DESCRIPTION
This allows different clients to use different configurations. My company is having the situation where we are using mollie for two different companies, which means we need to use two different apikeys. Without this change, we could not use this library. 

Also the way the client is created

`new ClientBuilder().withApiKey(API_KEY).build()`


 implies that this would already work. I was suprised that it did not and took me some digging until I figured out why. 

I hope this contribution is acceptable. If not, please get in touch with me. 